### PR TITLE
add refactoring.md to match the OpenDCS project

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactoring.md
+++ b/.github/ISSUE_TEMPLATE/refactoring.md
@@ -1,0 +1,24 @@
+---
+name: Code Refactoring
+about: Record to track modernization of the software
+title: ''
+labels: refactor, priority-medium
+assignees: '@opendcs-core-devs'
+
+---
+
+<!-- This template is intended for developer discussion. Both internal and external developers are welcome to propose things. 
+   For usage of the software or a general "I want to the software to also do X", please use the bug or feature template. 
+-->
+
+**Component to be refactored**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Purpose of refactoring**
+A clear and concise description of why we're changing a section of code
+
+**Proposed method**
+A discussion of how the code will be changed.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
## Problem Description

A refactoring issue template exists in the OpenDCS repository but not for the whole organization. The rest_api repository will likely have refactoring issues created under contract W912HQ23F0243 Task 5.

## Solution

Add refactoring.md from the OpenDCS repo.

## how you tested the change

N/A

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

